### PR TITLE
advertise windows client 1.1.2 as 1.1.2

### DIFF
--- a/client/latest.yml
+++ b/client/latest.yml
@@ -1,4 +1,4 @@
-version: 1.2.2
+version: 1.1.2
 files:
   - url: Outline-Client.exe
     sha512: I2Ze5Gjiq7D+ufV4d2HvOo4iws3s6lNcqqtb8ZbyuC1dAtHCZH7fAdenUs6IxVIfH9E4hXJvEFJHmsOQZiIecg==


### PR DESCRIPTION
Seems like downgrade from new -> old client doesn't work as intended: the new client stays. Let's advertise 1.1.2 as 1.1.2 so that at least users having issues with the new client can reinstall the old client from the website.