### PR TITLE
Upload to the S3 bucket on release 

### DIFF
--- a/release_linux_client.sh
+++ b/release_linux_client.sh
@@ -25,8 +25,8 @@ if [[ ! -f ~/.aws/credentials ]]; then
   echo "No AWS credentials file found.  Follow the instructions in the README to create one"
   exit 1
 fi
-if [[ ! grep --quiet '\[outline-releases\]' ~/.aws/credentials ]]; then
-  echo "No outline-releases profile found in AWS credentuals"
+if ! grep --quiet '\[outline-releases\]' ~/.aws/credentials ; then
+  echo "No outline-releases profile found in AWS credentials"
   exit 1
 fi
 

--- a/release_linux_client.sh
+++ b/release_linux_client.sh
@@ -18,6 +18,15 @@
 # prepares a commit on a new branch from which a pull request can easily
 # be made.
 
+if [[ ! -f ~/.aws/credentials ]]; then
+  echo "No AWS credentials file found.  Follow the instructions in the README to create one"
+  exit 1
+fi
+if [[ ! grep --quiet '\[outline-releases\]' ~/.aws/credentials ]]; then
+  echo "No outline-releases profile found in AWS credentuals"
+  exit 1
+fi
+
 declare -a FILES=(
   Outline-Client.AppImage
   latest-linux.yml
@@ -84,3 +93,4 @@ git checkout -b linux-client-$VERSION
 git commit -a -m "release linux client $VERSION"
 git branch
 git push origin linux-client-$VERSION
+aws s3 sync client s3://outline-releases/client --profile=outline-releases

--- a/release_linux_client.sh
+++ b/release_linux_client.sh
@@ -18,6 +18,9 @@
 # prepares a commit on a new branch from which a pull request can easily
 # be made.
 
+if [[ ! "$(aws --version)" ]]; then
+  echo "AWS CLI isn't installed.  See https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html."
+fi
 if [[ ! -f ~/.aws/credentials ]]; then
   echo "No AWS credentials file found.  Follow the instructions in the README to create one"
   exit 1

--- a/release_windows_client.sh
+++ b/release_windows_client.sh
@@ -25,8 +25,8 @@ if [[ ! -f ~/.aws/credentials ]]; then
   echo "No AWS credentials file found.  Follow the instructions in the README to create one"
   exit 1
 fi
-if [[ ! grep --quiet '\[outline-releases\]' ~/.aws/credentials ]]; then
-  echo "No outline-releases profile found in AWS credentuals"
+if ! grep --quiet '\[outline-releases\]' ~/.aws/credentials ; then
+  echo "No outline-releases profile found in AWS credentials"
   exit 1
 fi
 

--- a/release_windows_client.sh
+++ b/release_windows_client.sh
@@ -18,6 +18,9 @@
 # prepares a commit on a new branch from which a pull request can easily
 # be made.
 
+if [[ ! "$(aws --version)" ]]; then
+  echo "AWS CLI isn't installed.  See https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html."
+fi
 if [[ ! -f ~/.aws/credentials ]]; then
   echo "No AWS credentials file found.  Follow the instructions in the README to create one"
   exit 1

--- a/release_windows_client.sh
+++ b/release_windows_client.sh
@@ -18,6 +18,15 @@
 # prepares a commit on a new branch from which a pull request can easily
 # be made.
 
+if [[ ! -f ~/.aws/credentials ]]; then
+  echo "No AWS credentials file found.  Follow the instructions in the README to create one"
+  exit 1
+fi
+if [[ ! grep --quiet '\[outline-releases\]' ~/.aws/credentials ]]; then
+  echo "No outline-releases profile found in AWS credentuals"
+  exit 1
+fi
+
 declare -a FILES=(
   Outline-Client.exe
   latest.yml
@@ -84,3 +93,4 @@ git checkout -b windows-client-$VERSION
 git commit -a -m "release windows client $VERSION"
 git branch
 git push origin windows-client-$VERSION
+aws s3 sync client s3://outline-releases/client --profile=outline-releases


### PR DESCRIPTION
This commit has corresponding changes:

https://github.com/Jigsaw-Code/outline-client/pull/618 to pull from the s3 bucket with electron-update

and in the permissions to the s3 bucket, which should be inspected
separately before approving this PR