### PR TITLE
Upload to per-platform directories in S3

### DIFF
--- a/release_linux_client.sh
+++ b/release_linux_client.sh
@@ -101,8 +101,8 @@ git push origin linux-client-$VERSION
 # we have to publish to per-platform directories.
 # TODO(cohenjon) Remove this after the first platform-specific directory release
 for file in ${FILES[@]}; do
-  aws s3 cp "${file}" s3://outline-releases/client/"${file}" --profile-outline-releases
-  aws s3 cp "${file}" s3://outline-releases/client/linux/"${file}" --profile-outline-releases
+  aws s3 cp "${file}" s3://outline-releases/client/"${file}" --profile=outline-releases
+  aws s3 cp "${file}" s3://outline-releases/client/linux/"${file}" --profile=outline-releases
 done
 
 popd >/dev/null

--- a/release_linux_client.sh
+++ b/release_linux_client.sh
@@ -96,6 +96,13 @@ git checkout -b linux-client-$VERSION
 git commit -a -m "release linux client $VERSION"
 git branch
 git push origin linux-client-$VERSION
-aws s3 sync . s3://outline-releases/client --profile=outline-releases
+
+# S3's Metrics filters don't accept special characters besides the path delimiter, so 
+# we have to publish to per-platform directories.
+# TODO(cohenjon) Remove this after the first platform-specific directory release
+for file in ${FILES[@]}; do
+  aws s3 cp "${file}" s3://outline-releases/client/"${file}" --profile-outline-releases
+  aws s3 cp "${file}" s3://outline-releases/client/linux/"${file}" --profile-outline-releases
+done
 
 popd >/dev/null

--- a/release_windows_client.sh
+++ b/release_windows_client.sh
@@ -101,6 +101,6 @@ git push origin windows-client-$VERSION
 # we have to publish to per-platform directories.
 # TODO(cohenjon) Remove this after the first platform-specific directory release
 for file in ${FILES[@]}; do
-  aws s3 cp "${file}" s3://outline-releases/client/"${file}" --profile-outline-releases
-  aws s3 cp "${file}" s3://outline-releases/client/windows/"${file}" --profile-outline-releases
+  aws s3 cp "${file}" s3://outline-releases/client/"${file}" --profile=outline-releases
+  aws s3 cp "${file}" s3://outline-releases/client/windows/"${file}" --profile=outline-releases
 done

--- a/release_windows_client.sh
+++ b/release_windows_client.sh
@@ -96,4 +96,11 @@ git checkout -b windows-client-$VERSION
 git commit -a -m "release windows client $VERSION"
 git branch
 git push origin windows-client-$VERSION
-aws s3 sync client s3://outline-releases/client --profile=outline-releases
+
+# S3's Metrics filters don't accept special characters besides the path delimiter, so 
+# we have to publish to per-platform directories.
+# TODO(cohenjon) Remove this after the first platform-specific directory release
+for file in ${FILES[@]}; do
+  aws s3 cp "${file}" s3://outline-releases/client/"${file}" --profile-outline-releases
+  aws s3 cp "${file}" s3://outline-releases/client/windows/"${file}" --profile-outline-releases
+done


### PR DESCRIPTION
S3 buckets have no actual directory structure, just prefixes with delimiters.  You can filter metrics for requests on different objects by the prefix of the request.  These filters don't just work on "directory-like" prefixes, they work up until the first non-delimiter special character in the filename (eg if we we wanted to track requests for client/latest-linux.yml, we would have to use client/latest, not client/latest-linux). This means that in order to differentiate between GET requests for linux and windows binaries and config files, we need them to be in their own directories.

This corresponds with https://github.com/Jigsaw-Code/outline-client/pull/682.  We will need to merge  both, then cut a release of the client, then wait for requests to client/foo to go to zero before stopping publishing to both locations.