### PR TITLE
Release to per-platform directories

### DIFF
--- a/release_linux_client.sh
+++ b/release_linux_client.sh
@@ -97,6 +97,12 @@ git commit -a -m "release linux client $VERSION"
 git branch
 git push origin linux-client-$VERSION
 
-aws s3 sync . s3://outline-releases/client --profile=outline-releases
+# S3's Metrics filters don't accept special characters besides the path delimiter, so 
+# we have to publish to per-platform directories.
+# TODO(cohenjon) Remove the first line in the loop once requests to those files go to 0.
+for file in ${FILES[@]}; do
+  aws s3 cp "${file}" s3://outline-releases/client/"${file}" --profile=outline-releases
+  aws s3 cp "${file}" s3://outline-releases/client/linux/"${file}" --profile=outline-releases
+done
 
 popd >/dev/null

--- a/release_windows_client.sh
+++ b/release_windows_client.sh
@@ -97,4 +97,10 @@ git commit -a -m "release windows client $VERSION"
 git branch
 git push origin windows-client-$VERSION
 
-aws s3 sync . s3://outline-releases/client --profile=outline-releases
+# S3's Metrics filters don't accept special characters besides the path delimiter, so 
+# we have to publish to per-platform directories.
+# TODO(cohenjon) Remove the first line in the loop once requests to those files go to 0.
+for file in ${FILES[@]}; do
+  aws s3 cp "${file}" s3://outline-releases/client/"${file}" --profile=outline-releases
+  aws s3 cp "${file}" s3://outline-releases/client/windows/"${file}" --profile=outline-releases
+done


### PR DESCRIPTION
S3 buckets have no actual directory structure, just prefixes with delimiters. You can filter metrics for requests on different objects by the prefix of the request. These filters don't just work on "directory-like" prefixes, they work up until the first non-delimiter special character in the filename (eg if we we wanted to track requests for client/latest-linux.yml, we would have to use client/latest, not client/latest-linux). This means that in order to differentiate between GET requests for linux and windows binaries and config files, we need them to be in their own directories.

This corresponds with Jigsaw-Code/outline-client#682. We will need to merge both, then cut a release of the client, then wait for requests to client/foo to go to zero before stopping publishing to both locations.