### PR TITLE
Upload desktop client releases to S3 only after successful merge to master

### DIFF
--- a/.github/workflows/upload_linux_client_to_s3.yml
+++ b/.github/workflows/upload_linux_client_to_s3.yml
@@ -1,0 +1,52 @@
+# Copyright 2021 The Outline Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Uploads releases to the S3 bucket once the PR adding them is merged to master.  Currently we
+# only host desktop clients on S3, so those are the only ones pushed.
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - client/latest-linux.yml
+jobs:
+  linux_client:
+    name: Upload Linux Client
+
+    runs-on: ubuntu-16.04
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v1
+
+      - name: Install AWS CLI
+        run: |
+          sudo apt-get install awscli
+          aws --version
+
+      - name: Upload Linux Client to S3
+        env:
+          AWS_ACCESS_KEY_ID: {{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: {{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run:
+          declare -a FILES=(
+            Outline-Client.AppImage
+            latest-linux.yml
+          )
+          # TODO(cohenjon) Remove the first line in the loop once requests to those files go to 0.
+          for file in ${FILES[@]}; do
+            aws s3 cp "${file}" s3://outline-releases/client/"${file}" --profile=outline-releases
+            aws s3 cp "${file}" s3://outline-releases/client/linux/"${file}" --profile=outline-releases
+          done

--- a/.github/workflows/upload_windows_client_to_s3.yml
+++ b/.github/workflows/upload_windows_client_to_s3.yml
@@ -1,0 +1,52 @@
+# Copyright 2021 The Outline Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Uploads releases to the S3 bucket once the PR adding them is merged to master.  Currently we
+# only host desktop clients on S3, so those are the only ones pushed.
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - client/latest.yml
+jobs:
+  linux_client:
+    name: Upload Windows Client
+
+    runs-on: ubuntu-16.04
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v1
+
+      - name: Install AWS CLI
+        run: |
+          sudo apt-get install awscli
+          aws --version
+
+      - name: Upload Windows Client to S3
+        env:
+          AWS_ACCESS_KEY_ID: {{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: {{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run:
+          declare -a FILES=(
+            Outline-Client.AppImage
+            latest.yml
+          )
+          # TODO(cohenjon) Remove the first line in the loop once requests to those files go to 0.
+          for file in ${FILES[@]}; do
+            aws s3 cp "${file}" s3://outline-releases/client/"${file}" --profile=outline-releases
+            aws s3 cp "${file}" s3://outline-releases/client/windows/"${file}" --profile=outline-releases
+          done

--- a/release_linux_client.sh
+++ b/release_linux_client.sh
@@ -18,18 +18,6 @@
 # prepares a commit on a new branch from which a pull request can easily
 # be made.
 
-if [[ ! "$(aws --version)" ]]; then
-  echo "AWS CLI isn't installed.  See https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html."
-fi
-if [[ ! -f ~/.aws/credentials ]]; then
-  echo "No AWS credentials file found.  Follow the instructions in the README to create one"
-  exit 1
-fi
-if ! grep --quiet '\[outline-releases\]' ~/.aws/credentials ; then
-  echo "No outline-releases profile found in AWS credentials"
-  exit 1
-fi
-
 declare -a FILES=(
   Outline-Client.AppImage
   latest-linux.yml
@@ -96,13 +84,5 @@ git checkout -b linux-client-$VERSION
 git commit -a -m "release linux client $VERSION"
 git branch
 git push origin linux-client-$VERSION
-
-# S3's Metrics filters don't accept special characters besides the path delimiter, so 
-# we have to publish to per-platform directories.
-# TODO(cohenjon) Remove the first line in the loop once requests to those files go to 0.
-for file in ${FILES[@]}; do
-  aws s3 cp "${file}" s3://outline-releases/client/"${file}" --profile=outline-releases
-  aws s3 cp "${file}" s3://outline-releases/client/linux/"${file}" --profile=outline-releases
-done
 
 popd >/dev/null

--- a/release_windows_client.sh
+++ b/release_windows_client.sh
@@ -18,18 +18,6 @@
 # prepares a commit on a new branch from which a pull request can easily
 # be made.
 
-if [[ ! "$(aws --version)" ]]; then
-  echo "AWS CLI isn't installed.  See https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html."
-fi
-if [[ ! -f ~/.aws/credentials ]]; then
-  echo "No AWS credentials file found.  Follow the instructions in the README to create one"
-  exit 1
-fi
-if ! grep --quiet '\[outline-releases\]' ~/.aws/credentials ; then
-  echo "No outline-releases profile found in AWS credentials"
-  exit 1
-fi
-
 declare -a FILES=(
   Outline-Client.exe
   latest.yml
@@ -96,11 +84,3 @@ git checkout -b windows-client-$VERSION
 git commit -a -m "release windows client $VERSION"
 git branch
 git push origin windows-client-$VERSION
-
-# S3's Metrics filters don't accept special characters besides the path delimiter, so 
-# we have to publish to per-platform directories.
-# TODO(cohenjon) Remove the first line in the loop once requests to those files go to 0.
-for file in ${FILES[@]}; do
-  aws s3 cp "${file}" s3://outline-releases/client/"${file}" --profile=outline-releases
-  aws s3 cp "${file}" s3://outline-releases/client/windows/"${file}" --profile=outline-releases
-done


### PR DESCRIPTION
This way we avoid uploading before the final PR has been approved.