### PR TITLE
build(ci): update runner's os versions to the latest Ubuntu

### DIFF
--- a/.github/workflows/upload_linux_client_to_s3.yml
+++ b/.github/workflows/upload_linux_client_to_s3.yml
@@ -25,7 +25,7 @@ jobs:
   linux_client:
     name: Upload Linux Client
 
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/upload_windows_client_to_s3.yml
+++ b/.github/workflows/upload_windows_client_to_s3.yml
@@ -25,7 +25,7 @@ jobs:
   linux_client:
     name: Upload Windows Client
 
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
All [workflows](https://github.com/Jigsaw-Code/outline-releases/actions/workflows/upload_windows_client_to_s3.yml) are failing now because [GitHub hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners) does not support `ubuntu-16.04`. Therefore I updated it to `ubuntu-latest`, which was the same as `ubuntu-20.04` at the time I was submitting this PR.