### PR TITLE
build(ci): fix the Windows S3 publishing script

### DIFF
--- a/.github/workflows/upload_windows_client_to_s3.yml
+++ b/.github/workflows/upload_windows_client_to_s3.yml
@@ -21,6 +21,8 @@ on:
       - master
     paths:
       - client/latest.yml
+  workflow_dispatch:
+
 jobs:
   linux_client:
     name: Upload Windows Client
@@ -40,12 +42,12 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run:
+        run: |
           declare -a FILES=(
-            Outline-Client.exe
-            latest.yml
+            "Outline-Client.exe"
+            "latest.yml"
           )
           for file in "${FILES[@]}"; do
-            aws s3 cp "client/${file}" s3://outline-releases/client/"${file}"
-            aws s3 cp "client/${file}" s3://outline-releases/client/windows/"${file}"
+            aws s3 cp "client/${file}" "s3://outline-releases/client/${file}"
+            aws s3 cp "client/${file}" "s3://outline-releases/client/windows/${file}"
           done


### PR DESCRIPTION
In this PR, I fixed the AWS S3 publishing script for Windows. The old bash script [does not work on the latest Ubuntu runner](https://github.com/Jigsaw-Code/outline-releases/runs/6116977854?check_suite_focus=true). In addition, I also enabled the "manual triggering" (i.e., `workflow_dispatch`) of this publishing action.