### PR TITLE
fix(windows): fix AWS CLI exit code 255 in GitHub action

### DIFF
--- a/.github/workflows/upload_windows_client_to_s3.yml
+++ b/.github/workflows/upload_windows_client_to_s3.yml
@@ -33,15 +33,14 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v1
 
-      - name: Install AWS CLI
-        run: |
-          sudo apt-get install -y awscli
-          aws --version
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Upload Windows Client to S3
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           declare -a FILES=(
             "Outline-Client.exe"


### PR DESCRIPTION
Use the official way to configure AWS credentials instead of raw environment variables as recommended here: https://github.com/aws/aws-cli/issues/5262#issuecomment-898998161. Because GitHub action cannot run `aws s3` successfully due to unknown `AWS_EC2_METADATA` or region issues.