### PR TITLE
fix(linux): fix the Linux AWS S3 publishing script

### DIFF
--- a/.github/workflows/upload_linux_client_to_s3.yml
+++ b/.github/workflows/upload_linux_client_to_s3.yml
@@ -21,6 +21,8 @@ on:
       - master
     paths:
       - client/latest-linux.yml
+  workflow_dispatch:
+
 jobs:
   linux_client:
     name: Upload Linux Client
@@ -31,21 +33,20 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v1
 
-      - name: Install AWS CLI
-        run: |
-          sudo apt-get install -y awscli
-          aws --version
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Upload Linux Client to S3
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run:
+        run: |
           declare -a FILES=(
-            Outline-Client.AppImage
-            latest-linux.yml
+            "Outline-Client.AppImage"
+            "latest-linux.yml"
           )
           for file in "${FILES[@]}"; do
-            aws s3 cp "client/${file}" s3://outline-releases/client/"${file}"
-            aws s3 cp "client/${file}" s3://outline-releases/client/linux/"${file}"
+            aws s3 cp "client/${file}" "s3://outline-releases/client/${file}"
+            aws s3 cp "client/${file}" "s3://outline-releases/client/linux/${file}"
           done

--- a/.github/workflows/upload_windows_client_to_s3.yml
+++ b/.github/workflows/upload_windows_client_to_s3.yml
@@ -24,7 +24,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  linux_client:
+  windows_client:
     name: Upload Windows Client
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
In this PR, I fixed the AWS S3 publishing script for Linux, it contains the fixed made to Windows (#178 & #179):

* run script syntax in Github Action
* enabled the "manual triggering" (i.e., `workflow_dispatch`)
* AWS credential configuration and default region
