### PR TITLE
release server manager v1.10.0

### DIFF
--- a/manager/latest-linux.yml
+++ b/manager/latest-linux.yml
@@ -1,10 +1,10 @@
-version: 1.9.0
+version: 1.10.0
 files:
-  - url: Outline-Manager.AppImage
-    sha512: irg1gS9nEx6GWiCeWiZYKqQWBdutW2Ix9uqFOqldwNX2FSBD5PKAT77jWcijZgWLG9XEhfPn84K16oB4c4W/7A==
-    size: 100853765
-    blockMapSize: 104473
-path: Outline-Manager.AppImage
-sha512: irg1gS9nEx6GWiCeWiZYKqQWBdutW2Ix9uqFOqldwNX2FSBD5PKAT77jWcijZgWLG9XEhfPn84K16oB4c4W/7A==
-releaseDate: '2021-09-28T16:38:06.638Z'
+  - url: https://s3.amazonaws.com/outline-releases/manager/linux/1.10.0/1/Outline-Manager.AppImage
+    sha512: 4Ypv5PruTV/RGuCnKYTYWyaSD42hc6OdlK8PrOJd96zSg9k3wAD5/Djy6pIH1QQiSidsgMOJPUfM4Pf8sMob6A==
+    size: 106805998
+    blockMapSize: 113410
+path: https://s3.amazonaws.com/outline-releases/manager/linux/1.10.0/1/Outline-Manager.AppImage
+sha512: 4Ypv5PruTV/RGuCnKYTYWyaSD42hc6OdlK8PrOJd96zSg9k3wAD5/Djy6pIH1QQiSidsgMOJPUfM4Pf8sMob6A==
+releaseDate: '2022-07-16T01:52:54.463Z'
 stagingPercentage: 100

--- a/manager/latest-mac.yml
+++ b/manager/latest-mac.yml
@@ -1,13 +1,17 @@
-version: 1.9.0
+version: 1.10.0
 files:
-  - url: https://s3.amazonaws.com/outline-releases/server_manager/mac/Outline-Manager.zip
-    sha512: RsMSpb6tBzdSBMQK4XZrsgsdj4VijdeeOmbci8E37698R5tvbGru8xLUAYTAz4EW4RvGvJg2AqumFW4qnYLaNg==
-    size: 98350290
-    blockMapSize: 104655
-  - url: https://s3.amazonaws.com/outline-releases/server_manager/mac/Outline-Manager.dmg
-    sha512: Mo8Fd/hsxFxTKZGddd6W4P9V+CQ8GleJKXkCRkSZ90rpFNxCjrcmcf/RiR3CFZOubYbqA0CjOlz+2HxKyvBNZw==
-    size: 101702614
-path: Outline-Manager.zip
-sha512: RsMSpb6tBzdSBMQK4XZrsgsdj4VijdeeOmbci8E37698R5tvbGru8xLUAYTAz4EW4RvGvJg2AqumFW4qnYLaNg==
-releaseDate: '2021-09-28T16:43:10.382Z'
-stagingPercentage: 100
+  - url: https://s3.amazonaws.com/outline-releases/manager/macos/1.10.0/1/Outline-Manager.zip
+    sha512: djBMduCWhKz6F833LUFvXhsK1DPdhucPWgRTqbO7mBKg+EZDtqKBrd7t7KxQmoQp3QMEQJLqXQHdzY6YjhKmew==
+    size: 99404940
+  - url: https://s3.amazonaws.com/outline-releases/manager/macos/stable/Outline-Manager.dmg
+    sha512: Bbwlru1k0LVh0fcDNSSMBYr5YiEif61Gks66LLvIOVYgqoIYpgGYrVnzyqr60dbnh0X/1BHa5XD+Tg5zHmmZqg==
+    size: 103015615
+  - url: https://s3.amazonaws.com/outline-releases/manager/macos/stable/Outline-Manager.dmg
+    sha512: Bbwlru1k0LVh0fcDNSSMBYr5YiEif61Gks66LLvIOVYgqoIYpgGYrVnzyqr60dbnh0X/1BHa5XD+Tg5zHmmZqg==
+    size: 103015615
+  - url: https://s3.amazonaws.com/outline-releases/manager/macos/stable/Outline-Manager.dmg
+    sha512: Bbwlru1k0LVh0fcDNSSMBYr5YiEif61Gks66LLvIOVYgqoIYpgGYrVnzyqr60dbnh0X/1BHa5XD+Tg5zHmmZqg==
+    size: 103015615
+path: https://s3.amazonaws.com/outline-releases/manager/macos/1.10.0/1/Outline-Manager.zip
+sha512: djBMduCWhKz6F833LUFvXhsK1DPdhucPWgRTqbO7mBKg+EZDtqKBrd7t7KxQmoQp3QMEQJLqXQHdzY6YjhKmew==
+releaseDate: '2022-07-15T20:12:52.218Z'

--- a/manager/latest-mac.yml
+++ b/manager/latest-mac.yml
@@ -1,16 +1,10 @@
 version: 1.9.0
 files:
-  - url: Outline-Manager.zip
+  - url: https://s3.amazonaws.com/outline-releases/server_manager/mac/Outline-Manager.zip
     sha512: RsMSpb6tBzdSBMQK4XZrsgsdj4VijdeeOmbci8E37698R5tvbGru8xLUAYTAz4EW4RvGvJg2AqumFW4qnYLaNg==
     size: 98350290
     blockMapSize: 104655
-  - url: Outline-Manager.dmg
-    sha512: Mo8Fd/hsxFxTKZGddd6W4P9V+CQ8GleJKXkCRkSZ90rpFNxCjrcmcf/RiR3CFZOubYbqA0CjOlz+2HxKyvBNZw==
-    size: 101702614
-  - url: Outline-Manager.dmg
-    sha512: Mo8Fd/hsxFxTKZGddd6W4P9V+CQ8GleJKXkCRkSZ90rpFNxCjrcmcf/RiR3CFZOubYbqA0CjOlz+2HxKyvBNZw==
-    size: 101702614
-  - url: Outline-Manager.dmg
+  - url: https://s3.amazonaws.com/outline-releases/server_manager/mac/Outline-Manager.dmg
     sha512: Mo8Fd/hsxFxTKZGddd6W4P9V+CQ8GleJKXkCRkSZ90rpFNxCjrcmcf/RiR3CFZOubYbqA0CjOlz+2HxKyvBNZw==
     size: 101702614
 path: Outline-Manager.zip

--- a/manager/latest.yml
+++ b/manager/latest.yml
@@ -1,9 +1,8 @@
-version: 1.9.0
+version: 1.10.0
 files:
-  - url: Outline-Manager.exe
-    sha512: Vn8jUQAyurvHlIoyIq3WkxeoDyjQYhmUK23g7g1QgTYXQfIOqghV6s+qjKxEKkch/rBa7sehz36g5eoqxtd6VQ==
-    size: 66830000
-path: Outline-Manager.exe
-sha512: Vn8jUQAyurvHlIoyIq3WkxeoDyjQYhmUK23g7g1QgTYXQfIOqghV6s+qjKxEKkch/rBa7sehz36g5eoqxtd6VQ==
-releaseDate: '2021-09-28T16:48:28.107Z'
-stagingPercentage: 100
+  - url: https://s3.amazonaws.com/outline-releases/manager/windows/1.10.0/1/Outline-Manager.exe
+    sha512: H/43uMKUcPNHjketx/L9PdACbf3gv2nBJ9aeqs+V43aysqnR9wNG7l5/uKandtTfuV7RKLosfCcu4wZzt+9ZMg==
+    size: 70994592
+path: https://s3.amazonaws.com/outline-releases/manager/windows/1.10.0/1/Outline-Manager.exe
+sha512: H/43uMKUcPNHjketx/L9PdACbf3gv2nBJ9aeqs+V43aysqnR9wNG7l5/uKandtTfuV7RKLosfCcu4wZzt+9ZMg==
+releaseDate: '2022-07-18T20:17:10.623Z'


### PR DESCRIPTION
All binaries have been published to Amazon S3 already, this commit will only update electron updater's yml files for legacy apps.