### PR TITLE
release server manager v1.10.0 (2) for macOS

### DIFF
--- a/manager/latest-mac.yml
+++ b/manager/latest-mac.yml
@@ -1,17 +1,17 @@
 version: 1.10.0
 files:
-  - url: https://s3.amazonaws.com/outline-releases/manager/macos/1.10.0/1/Outline-Manager.zip
-    sha512: djBMduCWhKz6F833LUFvXhsK1DPdhucPWgRTqbO7mBKg+EZDtqKBrd7t7KxQmoQp3QMEQJLqXQHdzY6YjhKmew==
-    size: 99404940
+  - url: https://s3.amazonaws.com/outline-releases/manager/macos/1.10.0/2/Outline-Manager.zip
+    sha512: GdjXROXhkztHJBB+3tXD7z3QY4zIWTmI8KV5i5utkKbeOVPwyC0IAECtv9ZBrl3Rvhr5TVb52bgRWC2YtQNlng==
+    size: 101589123
   - url: https://s3.amazonaws.com/outline-releases/manager/macos/stable/Outline-Manager.dmg
-    sha512: Bbwlru1k0LVh0fcDNSSMBYr5YiEif61Gks66LLvIOVYgqoIYpgGYrVnzyqr60dbnh0X/1BHa5XD+Tg5zHmmZqg==
-    size: 103015615
+    sha512: ZxAM05uK/IX5YACT+Rp8ja84cW/MnZRR2SYABvk4dK6x+WwPE3p8udjKh9aWDwwhOnWXaMSSFehUaF5oMudJmg==
+    size: 105603404
   - url: https://s3.amazonaws.com/outline-releases/manager/macos/stable/Outline-Manager.dmg
-    sha512: Bbwlru1k0LVh0fcDNSSMBYr5YiEif61Gks66LLvIOVYgqoIYpgGYrVnzyqr60dbnh0X/1BHa5XD+Tg5zHmmZqg==
-    size: 103015615
+    sha512: ZxAM05uK/IX5YACT+Rp8ja84cW/MnZRR2SYABvk4dK6x+WwPE3p8udjKh9aWDwwhOnWXaMSSFehUaF5oMudJmg==
+    size: 105603404
   - url: https://s3.amazonaws.com/outline-releases/manager/macos/stable/Outline-Manager.dmg
-    sha512: Bbwlru1k0LVh0fcDNSSMBYr5YiEif61Gks66LLvIOVYgqoIYpgGYrVnzyqr60dbnh0X/1BHa5XD+Tg5zHmmZqg==
-    size: 103015615
-path: https://s3.amazonaws.com/outline-releases/manager/macos/1.10.0/1/Outline-Manager.zip
-sha512: djBMduCWhKz6F833LUFvXhsK1DPdhucPWgRTqbO7mBKg+EZDtqKBrd7t7KxQmoQp3QMEQJLqXQHdzY6YjhKmew==
-releaseDate: '2022-07-15T20:12:52.218Z'
+    sha512: ZxAM05uK/IX5YACT+Rp8ja84cW/MnZRR2SYABvk4dK6x+WwPE3p8udjKh9aWDwwhOnWXaMSSFehUaF5oMudJmg==
+    size: 105603404
+path: https://s3.amazonaws.com/outline-releases/manager/macos/1.10.0/2/Outline-Manager.zip
+sha512: GdjXROXhkztHJBB+3tXD7z3QY4zIWTmI8KV5i5utkKbeOVPwyC0IAECtv9ZBrl3Rvhr5TVb52bgRWC2YtQNlng==
+releaseDate: '2022-07-27T21:52:28.159Z'


### PR DESCRIPTION
We uploaded a notarized version of server manager v1.10.0 for macOS, this will resolve the update issue.