### PR TITLE
Revert "Release: manager_macos/v1.15.0"

### DIFF
--- a/manager/latest-mac.yml
+++ b/manager/latest-mac.yml
@@ -1,8 +1,17 @@
-version: 1.15.1
+version: 1.14.0
 files:
-  - url: https://s3.amazonaws.com/outline-releases/manager_macos/v1.15.1/Outline-Manager.dmg
-    sha512: pOjMPPNALhc1j/YXKxxdlO3Cqj6EO2NahvOMhYCnbxKdjSZEOZGOOIvi6VTeFzBoo4BmGB/vJtmYuk54gKr+GA==
-    size: 171497589
-path: https://s3.amazonaws.com/outline-releases/manager_macos/v1.15.1/Outline-Manager.dmg
-sha512: pOjMPPNALhc1j/YXKxxdlO3Cqj6EO2NahvOMhYCnbxKdjSZEOZGOOIvi6VTeFzBoo4BmGB/vJtmYuk54gKr+GA==
-releaseDate: '2023-10-04T19:30:52.693Z'
+  - url: https://s3.amazonaws.com/outline-releases/manager/macos/1.14.0/1/Outline-Manager.zip
+    sha512: gxkgg+WRJdtfKtPPovP33DKHOTjwgmpStMYED5wgRCOboHIE+JG9gmy5uSUclk9j1b7OxkJkHmTJl1VkrXwz0A==
+    size: 101657161
+  - url: https://s3.amazonaws.com/outline-releases/manager/macos/stable/Outline-Manager.dmg
+    sha512: Ii/Vm8UgPi9ZdBfHGt1Wn0jyF5IQyDLLGMac/0zCDvbCuTm8nHS6caR/K7OW//fHMF04UBIwFerRQ0hQZBzYZg==
+    size: 105734531
+  - url: https://s3.amazonaws.com/outline-releases/manager/macos/stable/Outline-Manager.dmg
+    sha512: Ii/Vm8UgPi9ZdBfHGt1Wn0jyF5IQyDLLGMac/0zCDvbCuTm8nHS6caR/K7OW//fHMF04UBIwFerRQ0hQZBzYZg==
+    size: 105734531
+  - url: https://s3.amazonaws.com/outline-releases/manager/macos/stable/Outline-Manager.dmg
+    sha512: Ii/Vm8UgPi9ZdBfHGt1Wn0jyF5IQyDLLGMac/0zCDvbCuTm8nHS6caR/K7OW//fHMF04UBIwFerRQ0hQZBzYZg==
+    size: 105734531
+path: https://s3.amazonaws.com/outline-releases/manager/macos/1.14.0/1/Outline-Manager.zip
+sha512: gxkgg+WRJdtfKtPPovP33DKHOTjwgmpStMYED5wgRCOboHIE+JG9gmy5uSUclk9j1b7OxkJkHmTJl1VkrXwz0A==
+releaseDate: '2023-02-14T21:33:08.531Z'


### PR DESCRIPTION
This reverts commit 315531baeedefb5e18acd76fd47545e68330df63. Rolling back latest to 1.14.0. See https://github.com/Jigsaw-Code/outline-server/issues/1426 for details.